### PR TITLE
TESTING Use brew to install protobuf on Travis

### DIFF
--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -11,7 +11,8 @@ mkdir -p $DOWNLOAD_DIR
 # Can't check for presence of directory as cache auto-creates it.
 if [ -f ${INSTALL_DIR}/bin/protoc ]; then
   echo "Not building protobuf. Already built"
-# TODO(ejona): swap to `brew install --devel protobuf` once it is up-to-date
+elif [ "$(uname)" = Darwin ]; then
+  brew install --devel protobuf
 else
   wget -O - https://github.com/google/protobuf/archive/v${PROTOBUF_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
   pushd $DOWNLOAD_DIR/protobuf-${PROTOBUF_VERSION}


### PR DESCRIPTION
Brew now has beta-1, and is much faster than compiling each time.