### PR TITLE
TESTING Swap to "old" link for OpenSSL download with Travis

### DIFF
--- a/buildscripts/make_dependencies.sh
+++ b/buildscripts/make_dependencies.sh
@@ -30,7 +30,10 @@ if [ -f ${INSTALL_DIR}/lib/libssl.so ]; then
 elif [ "$(uname)" = Darwin ]; then
   brew install openssl
 else
-  wget -O - https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz | tar xz -C $DOWNLOAD_DIR
+  # The version without the patch letter (e.g., 1.0.2 provided 1.0.2d)
+  VERSION_BASE=${OPENSSL_VERSION%%[a-z]*}
+  wget -O - https://www.openssl.org/source/old/$VERSION_BASE/openssl-${OPENSSL_VERSION}.tar.gz \
+    | tar xz -C $DOWNLOAD_DIR
   pushd $DOWNLOAD_DIR/openssl-${OPENSSL_VERSION}
   ./Configure linux-x86_64 shared no-ssl2 no-comp --prefix=${INSTALL_DIR}
   make -j$(nproc)


### PR DESCRIPTION
The previous download link only worked for the most recent version. The
new form only works for old versions. That will encourage us not to use
the latest version, but for tests that's probably not a big deal.