### PR TITLE
Test: Add support for codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      enabled: true
+      threshold: "1%"
+    patch:
+      enabled: true
+      target: "90%"
+    changes:
+      enabled: true
+  ignore:
+    - "all/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,13 @@ install:
 before_script:
   - test -z "$(git status --porcelain)" || (git status && echo Error Working directory is not clean. Forget to commit generated files? && false)
 
+script:
+  - ./gradlew check
+  - ./gradlew jacocoTestReport
+
 after_success:
   - if \[ "$TRAVIS_OS_NAME" = linux \]; then ./gradlew :grpc-all:coveralls; fi
+  - bash <(curl -s https://codecov.io/bash)
 
 os:
   - linux


### PR DESCRIPTION
Codecov.io provides patch-based code coverage, so you can easily know
how many of the added lines are covered.