### PR TITLE
.github/workflows: Split Bazel into two jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,8 +77,14 @@ jobs:
 
   bazel:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        - bazel: 6.0.0
+          bzlmod: false
+        - bazel: 7.0.0
+          bzlmod: true
     env:
-      USE_BAZEL_VERSION: 6.0.0
+      USE_BAZEL_VERSION: ${{ matrix.bazel }}
 
     steps:
     - uses: actions/checkout@v4
@@ -97,19 +103,8 @@ jobs:
         key: ${{ runner.os }}-bazel-${{ env.USE_BAZEL_VERSION }}-${{ hashFiles('WORKSPACE', 'repositories.bzl') }}
 
     - name: Run bazel build
-      run: bazelisk build //... --enable_bzlmod=false
+      run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }}
 
     - name: Run example bazel build
-      run: bazelisk build //... --enable_bzlmod=false
-      working-directory: ./examples
-
-    - name: Run bazel build (bzlmod)
-      env:
-        USE_BAZEL_VERSION: 7.0.0
-      run: bazelisk build //... --enable_bzlmod=true
-
-    - name: Run example bazel build (bzlmod)
-      env:
-        USE_BAZEL_VERSION: 7.0.0
-      run: bazelisk build //... --enable_bzlmod=true
+      run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }}
       working-directory: ./examples

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,10 +78,12 @@ jobs:
   bazel:
     runs-on: ubuntu-latest
     strategy:
-      - matrix.bazel: 6.0.0
-        matrix.bzlmod: false
-      - matrix.bazel: 7.0.0
-        matrix.bzlmod: true
+      matrix:
+        include:
+          - bazel: 6.0.0
+            bzlmod: false
+          - bazel: 7.0.0
+            bzlmod: true
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,11 +78,10 @@ jobs:
   bazel:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        - bazel: 6.0.0
-          bzlmod: false
-        - bazel: 7.0.0
-          bzlmod: true
+      - matrix.bazel: 6.0.0
+        matrix.bzlmod: false
+      - matrix.bazel: 7.0.0
+        matrix.bzlmod: true
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel }}
 


### PR DESCRIPTION
The two Bazel builds are completely separate; no need to run them serially.